### PR TITLE
fix ContainerAzure.getMetadata() to return metadata for the exact blob path

### DIFF
--- a/lib/azure.js
+++ b/lib/azure.js
@@ -19,6 +19,7 @@ const validUrl = require('valid-url');
 
 const { StringUtils } = require('./string-utils.js');
 const { CDN } = require('./cdn.js');
+const { BlobURL } = require('@azure/storage-blob');
 
 class ContainerAzure {
 
@@ -313,12 +314,21 @@ class ContainerAzure {
      */
     async getMetadata (blobName) {
 
-        const list = await this.listObjects(blobName);
+        try {
+            const blobURL = BlobURL.fromContainerURL(this.containerURL, blobName);
+            const metadata = await blobURL.getProperties(storage.Aborter.none);
+            // to stay backwards compatible
+            metadata.name = blobName;
 
-        if (list.length !== 1) {
-            return;
+            return metadata;
+        } catch (e) {
+            if (e.statusCode === 404) {
+                console.log("Error: Could not find blob", blobName);
+            } else {
+                console.log(e);
+            }
+            return undefined;
         }
-        return list[0];
     }
 }
 


### PR DESCRIPTION
Previously `ContainerAzure.getMetadata()` failed if there were multiple blobs matching the given path (`blobName` argument) as prefix. this now also returns a lot more metadata for the blob.

Old metadata:

```js
{
  name: 'images/jpeg/1.JPG',
  contentLength: 24759,
  contentType: 'image/jpeg'
}
```

New metadata:

```js
{
  name: 'images/jpeg/1.JPG',
  lastModified: 2019-09-05T19:50:43.000Z,
  creationTime: 2019-09-05T19:50:43.000Z,
  metadata: {},
  blobType: 'BlockBlob',
  copyCompletionTime: 2019-09-05T19:50:43.000Z,
  copyStatusDescription: undefined,
  copyId: 'c55678e4-9424-4191-a1d6-ef1337c2781c',
  copyProgress: '24759/24759',
  copySource: 'https://adobe-sample-asset-repository.s3.amazonaws.com/images/jpeg/1.JPG?REDACTED,
  copyStatus: 'success',
  isIncrementalCopy: undefined,
  destinationSnapshot: undefined,
  leaseDuration: undefined,
  leaseState: 'available',
  leaseStatus: 'unlocked',
  contentLength: 24759,
  contentType: 'image/jpeg',
  eTag: '"0x8D7323A567C8DC8"',
  contentMD5: undefined,
  contentEncoding: undefined,
  contentDisposition: undefined,
  contentLanguage: undefined,
  cacheControl: undefined,
  blobSequenceNumber: undefined,
  clientRequestId: '0b6ff2ac-e544-4139-a3c3-61389cd5a7d0',
  requestId: 'f5025b01-701e-0156-6f18-a4c204000000',
  version: '2019-02-02',
  date: 2020-10-16T23:57:17.000Z,
  acceptRanges: 'bytes',
  blobCommittedBlockCount: undefined,
  isServerEncrypted: true,
  encryptionKeySha256: undefined,
  accessTier: 'Hot',
  accessTierInferred: true,
  archiveStatus: undefined,
  accessTierChangeTime: undefined,
  errorCode: undefined,
  body: true
}
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

